### PR TITLE
fix circular import when using create_tables

### DIFF
--- a/remodel/registry.py
+++ b/remodel/registry.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from .errors import AlreadyRegisteredError
-import remodel.models
 
 
 class ModelRegistry(object):
@@ -12,6 +11,8 @@ class ModelRegistry(object):
         return len(self._data)
 
     def register(self, name, cls):
+        import remodel.models
+
         if name in self._data:
             raise AlreadyRegisteredError('Model "%s" has been already registered' % name)
         if not issubclass(cls, remodel.models.Model):


### PR DESCRIPTION
I was calling ```create_tables``` in my own helper script and it was causing a circular import.
Importing the models locally in the method that needs it fixes that issue.