### PR TITLE
Moved the deletion of the 'id' attribute to after the removal of related fields

### DIFF
--- a/remodel/models.py
+++ b/remodel/models.py
@@ -75,9 +75,7 @@ class Model(object):
             result = (r.table(self.table_name).get(id_).replace(r.row
                         .without(r.row.keys().difference(list(fields_dict.keys())))
                         .merge(fields_dict), return_changes='always').run())
-            if result['errors'] > 0:
-                raise Exception(result['first_error'])
-        except:
+        except KeyError:
             # Resort to insert
             result = (r.table(self.table_name).insert(fields_dict, return_changes=True)
                       .run())

--- a/remodel/models.py
+++ b/remodel/models.py
@@ -109,11 +109,11 @@ class Model(object):
         if result['errors'] > 0:
             raise OperationError(result['first_error'])
 
-        delattr(self.fields, 'id')
         # Remove any reference to the deleted object
         for field in self.fields.related:
             delattr(self.fields, field)
 
+        delattr(self.fields, 'id')
         self._run_callbacks('after_delete')
 
     # TODO: Get rid of this nasty decorator after renaming .get() on ObjectHandler

--- a/remodel/models.py
+++ b/remodel/models.py
@@ -75,6 +75,7 @@ class Model(object):
             result = (r.table(self.table_name).get(id_).replace(r.row
                         .without(r.row.keys().difference(list(fields_dict.keys())))
                         .merge(fields_dict), return_changes='always').run())
+
         except KeyError:
             # Resort to insert
             result = (r.table(self.table_name).insert(fields_dict, return_changes=True)

--- a/remodel/models.py
+++ b/remodel/models.py
@@ -111,8 +111,8 @@ class Model(object):
         # Remove any reference to the deleted object
         for field in self.fields.related:
             delattr(self.fields, field)
-
         delattr(self.fields, 'id')
+
         self._run_callbacks('after_delete')
 
     # TODO: Get rid of this nasty decorator after renaming .get() on ObjectHandler

--- a/remodel/models.py
+++ b/remodel/models.py
@@ -75,8 +75,9 @@ class Model(object):
             result = (r.table(self.table_name).get(id_).replace(r.row
                         .without(r.row.keys().difference(list(fields_dict.keys())))
                         .merge(fields_dict), return_changes='always').run())
-
-        except KeyError:
+            if result['errors'] > 0:
+                raise Exception(result['first_error'])
+        except:
             # Resort to insert
             result = (r.table(self.table_name).insert(fields_dict, return_changes=True)
                       .run())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -353,8 +353,27 @@ class DeleteTests(DbBaseTestCase):
         super(DeleteTests, self).setUp()
 
         class Artist(Model):
-            pass
+            belongs_to = ('Label',)
+            has_one = ('TrueFan',)
+            has_many = ('Fan',)
+            has_and_belongs_to_many = ('Band',)
         self.Artist = Artist
+
+        class Label(Model):
+            pass
+        self.Label = Label
+
+        class TrueFan(Model):
+            pass
+        self.TrueFan = TrueFan
+
+        class Fan(Model):
+            pass
+        self.Fan = Fan
+
+        class Band(Model):
+            pass
+        self.Band = Band
 
         create_tables()
         create_indexes()


### PR DESCRIPTION
I've been unable to cleanly delete certain Model objects because the `id` attribute disappears before remodel is finished with it.  Simply moving the removal of that attribute to below the part where we remove the relations solves this problem for me.

```
class Application:
  has_and_belongs_to_many('User',)

class User:
  has_and_belongs_to_many('Application',)

a = Application.get('some-application-id')
a.delete()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/remodel/models.py", line 116, in delete
    delattr(self.fields, field)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/remodel/field_handler.py", line 84, in __delattr__
    super(FieldHandler, self).__delattr__(name)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/remodel/related.py", line 297, in __delete__
    rel_m2m_object_handler.clear()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/remodel/related.py", line 256, in clear
    .get_all(self._get_parent_lkey(), index=mlkey)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/remodel/related.py", line 263, in _get_parent_lkey
    'instance isn\'t saved' %  model_cls.__name__)
ValueError: Cannot access related "User" set: current instance isn't saved
```