### PR TITLE
Update to rethinkdb>=2.4

### DIFF
--- a/remodel/connection.py
+++ b/remodel/connection.py
@@ -1,5 +1,4 @@
-
-import rethinkdb as r
+from rethinkdb import r
 from contextlib import contextmanager
 try:
     from queue import Queue, Empty
@@ -74,4 +73,3 @@ def get_conn():
         yield conn
     finally:
         pool.put(conn)
-

--- a/remodel/helpers.py
+++ b/remodel/helpers.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 
 
 def create_tables():

--- a/remodel/models.py
+++ b/remodel/models.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from six import add_metaclass
 from inflection import tableize
 

--- a/remodel/monkey.py
+++ b/remodel/monkey.py
@@ -1,9 +1,9 @@
-import rethinkdb as r
+from rethinkdb import ast
 
 import remodel.connection
 
 
-run = r.ast.RqlQuery.run
+run = ast.RqlQuery.run
 
 def remodel_run(self, c=None, **global_optargs):
     """
@@ -17,4 +17,4 @@ def remodel_run(self, c=None, **global_optargs):
     else:
         return run(self, c, **global_optargs)
 
-r.ast.RqlQuery.run = remodel_run
+ast.RqlQuery.run = remodel_run

--- a/remodel/object_handler.py
+++ b/remodel/object_handler.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 
 
 class ObjectHandler(object):

--- a/remodel/related.py
+++ b/remodel/related.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from inflection import tableize
 
 from .decorators import cached_property

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'rethinkdb',
+        'rethinkdb>=2.4',
         'inflection',
         'six'
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 import os
-import rethinkdb as r
+from rethinkdb import r
 from rethinkdb.errors import RqlDriverError
 import unittest
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 
 from remodel.helpers import create_tables, drop_tables, create_indexes
 from remodel.models import Model

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-import rethinkdb as r
+from rethinkdb import r
 
 from remodel.errors import OperationError
 from remodel.helpers import create_tables, create_indexes

--- a/tests/test_object_handler.py
+++ b/tests/test_object_handler.py
@@ -1,5 +1,5 @@
 import pytest
-import rethinkdb as r
+from rethinkdb import r
 import unittest
 
 from remodel.connection import get_conn


### PR DESCRIPTION
Add support for the "new" `rethinkdb` package, versions above (and including) 2.4.

Closes #59 