### PR TITLE
Remove deprecated stuff

### DIFF
--- a/remodel/models.py
+++ b/remodel/models.py
@@ -7,7 +7,6 @@ from .errors import OperationError
 from .field_handler import FieldHandlerBase, FieldHandler
 from .object_handler import ObjectHandler
 from .registry import model_registry
-from .utils import deprecation_warning
 
 
 REL_TYPES = ('has_one', 'has_many', 'belongs_to', 'has_and_belongs_to_many')

--- a/remodel/utils.py
+++ b/remodel/utils.py
@@ -3,20 +3,6 @@ from warnings import warn
 from .decorators import synchronized
 
 
-def create_tables():
-    from .helpers import create_tables as ct
-    deprecation_warning('remodel.utils.create_tables will be deprecated soon. '
-                        'Please use remodel.helpers.create_tables instead.')
-    ct()
-
-
-def create_indexes():
-    from .helpers import create_indexes as ci
-    deprecation_warning('remodel.utils.create_indexes will be deprecated soon. '
-                        'Please use remodel.helpers.create_indexes instead.')
-    ci()
-
-
 class Counter(object):
     lock = Lock()
 


### PR DESCRIPTION
Remove `remodel.utils.create_tables` and `remodel.utils.create_indexes`.