### PR TITLE
Use Model.table_name and drop Model._table

### DIFF
--- a/remodel/helpers.py
+++ b/remodel/helpers.py
@@ -6,11 +6,11 @@ def create_tables():
 
     created_tables = r.table_list().run()
     for model_cls in model_registry.all().values():
-        if model_cls._table not in created_tables:
-            result = r.table_create(model_cls._table).run()
+        if model_cls.table_name not in created_tables:
+            result = r.table_create(model_cls.table_name).run()
             if result['tables_created'] != 1:
                 raise RuntimeError('Could not create table %s for model %s' % (
-                                   model_cls._table, model_cls.__name__))
+                                   model_cls.table_name, model_cls.__name__))
 
 
 def drop_tables():
@@ -18,11 +18,11 @@ def drop_tables():
 
     created_tables = r.table_list().run()
     for model_cls in model_registry.all().values():
-        if model_cls._table in created_tables:
-            result = r.table_drop(model_cls._table).run()
+        if model_cls.table_name in created_tables:
+            result = r.table_drop(model_cls.table_name).run()
             if result['tables_dropped'] != 1:
                 raise RuntimeError('Could not drop table %s for model %s' % (
-                                   model_cls._table, model_cls.__name__))
+                                   model_cls.table_name, model_cls.__name__))
 
 
 def create_indexes():
@@ -30,11 +30,11 @@ def create_indexes():
 
     for model, index_set in index_registry.all().items():
         model_cls = model_registry.get(model)
-        created_indexes = r.table(model_cls._table).index_list().run()
+        created_indexes = r.table(model_cls.table_name).index_list().run()
         for index in index_set:
             if index not in created_indexes:
-                result = r.table(model_cls._table).index_create(index).run()
+                result = r.table(model_cls.table_name).index_create(index).run()
                 if result['created'] != 1:
                     raise RuntimeError('Could not create index %s for table %s' % (
-                                       index, model_cls._table))
-        r.table(model_cls._table).index_wait().run()
+                                       index, model_cls.table_name))
+        r.table(model_cls.table_name).index_wait().run()

--- a/remodel/models.py
+++ b/remodel/models.py
@@ -24,7 +24,7 @@ class ModelBase(type):
             return super_new(mcs, name, bases, dct)
 
         # Set metadata
-        dct['table_name'] = dct['_table'] = dct.get('table_name', tableize(name))
+        dct['table_name'] = dct.get('table_name', tableize(name))
 
         rel_attrs = {rel: dct.setdefault(rel, ()) for rel in REL_TYPES}
         dct['_field_handler_cls'] = FieldHandlerBase(
@@ -73,13 +73,13 @@ class Model(object):
         try:
             # Attempt update
             id_ = fields_dict['id']
-            result = (r.table(self._table).get(id_).replace(r.row
+            result = (r.table(self.table_name).get(id_).replace(r.row
                         .without(r.row.keys().difference(list(fields_dict.keys())))
                         .merge(fields_dict), return_changes='always').run())
 
         except KeyError:
             # Resort to insert
-            result = (r.table(self._table).insert(fields_dict, return_changes=True)
+            result = (r.table(self.table_name).insert(fields_dict, return_changes=True)
                       .run())
 
         if result['errors'] > 0:
@@ -102,7 +102,7 @@ class Model(object):
 
         try:
             id_ = getattr(self.fields, 'id')
-            result = r.table(self._table).get(id_).delete().run()
+            result = r.table(self.table_name).get(id_).delete().run()
         except AttributeError:
             raise OperationError('Cannot delete %r (object not saved or '
                                  'already deleted)' % self)

--- a/remodel/object_handler.py
+++ b/remodel/object_handler.py
@@ -4,7 +4,7 @@ from rethinkdb import r
 class ObjectHandler(object):
     def __init__(self, model_cls, query=None):
         self.model_cls = model_cls
-        self.query = query or r.table(model_cls._table)
+        self.query = query or r.table(model_cls.table_name)
 
     def __getattr__(self, name):
         return getattr(self.query, name)

--- a/remodel/related.py
+++ b/remodel/related.py
@@ -194,9 +194,9 @@ def create_related_m2m_object_handler_cls(model_cls, lkey, rkey, join_model_cls,
             # Parent field handler instance
             self.parent = parent
             # Returns all docs from model_cls which are referenced in join_model_cls
-            self.query = (r.table(join_model_cls._table)
+            self.query = (r.table(join_model_cls.table_name)
                           .get_all(self._get_parent_lkey(), index=mlkey)
-                          .eq_join(mrkey, r.table(model_cls._table), index=rkey)
+                          .eq_join(mrkey, r.table(model_cls.table_name), index=rkey)
                           .map(lambda res: res['right']))
 
         def create(self, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,7 +17,7 @@ class ModelTests(BaseTestCase):
         class Artist(Model):
             pass
 
-        assert hasattr(Artist, '_table')
+        assert hasattr(Artist, 'table_name')
         assert hasattr(Artist, 'has_one')
         assert hasattr(Artist, 'has_many')
         assert hasattr(Artist, 'has_and_belongs_to_many')
@@ -31,14 +31,12 @@ class ModelTests(BaseTestCase):
         class Artist(Model):
             pass
 
-        assert Artist._table == 'artists'
         assert Artist.table_name == 'artists'
 
     def test_custom_table_name(self):
         class Artist(Model):
             table_name = 'artist_tbl'
 
-        assert Artist._table == 'artist_tbl'
         assert Artist.table_name == 'artist_tbl'
 
     def test_default_object_handler_cls(self):
@@ -268,27 +266,27 @@ class SaveTests(DbBaseTestCase):
     def test_insert(self):
         a = self.Artist(name='Andrei')
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_update(self):
         a = self.Artist(name='Andrei')
         a.save()
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_update_with_added_field(self):
         a = self.Artist(name='Andrei')
         a.save()
         a['country'] = 'Romania'
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_update_with_removed_field(self):
         a = self.Artist(name='Andrei')
         a.save()
         del a['name']
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_belongs_to(self):
         p = self.Person()
@@ -296,7 +294,7 @@ class SaveTests(DbBaseTestCase):
         a = self.Artist()
         a['person'] = p
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_updated_belongs_to(self):
         p1 = self.Person()
@@ -308,7 +306,7 @@ class SaveTests(DbBaseTestCase):
         p2.save()
         a['person'] = p2
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_removed_belongs_to(self):
         p = self.Person()
@@ -318,7 +316,7 @@ class SaveTests(DbBaseTestCase):
         a.save()
         del a['person']
         a.save()
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_has_one(self):
         a = self.Artist()
@@ -326,7 +324,7 @@ class SaveTests(DbBaseTestCase):
         b = self.Bio()
         a['bio'] = b
         b.save()
-        self.assert_saved(b._table, b.fields.as_dict())
+        self.assert_saved(b.table_name, b.fields.as_dict())
 
     def test_updated_has_one(self):
         a = self.Artist()
@@ -337,7 +335,7 @@ class SaveTests(DbBaseTestCase):
         b2 = self.Bio()
         a['bio'] = b2
         b1.save()
-        self.assert_saved(b1._table, b1.fields.as_dict())
+        self.assert_saved(b1.table_name, b1.fields.as_dict())
 
     def test_removed_has_one(self):
         a = self.Artist()
@@ -347,7 +345,7 @@ class SaveTests(DbBaseTestCase):
         b.save()
         del a['bio']
         b.save()
-        self.assert_saved(b._table, b.fields.as_dict())
+        self.assert_saved(b.table_name, b.fields.as_dict())
 
 
 class DeleteTests(DbBaseTestCase):
@@ -431,32 +429,32 @@ class UpdateTests(DbBaseTestCase):
     def test_new_document_with_no_fields(self):
         a = self.Artist(name='Andrei')
         a.update()
-        self.assert_updated(a._table, a.fields.as_dict())
+        self.assert_updated(a.table_name, a.fields.as_dict())
 
     def test_new_document_with_one_field(self):
         a = self.Artist(name='Andrei')
         a.update(country='Romania')
-        self.assert_updated(a._table, a.fields.as_dict())
+        self.assert_updated(a.table_name, a.fields.as_dict())
 
     def test_new_document_with_several_fields(self):
         a = self.Artist(name='Andrei')
         a.update(country='Romania', city='Timisoara', male=True)
-        self.assert_updated(a._table, a.fields.as_dict())
+        self.assert_updated(a.table_name, a.fields.as_dict())
 
     def test_existing_document_with_no_fields(self):
         a = self.Artist.create(name='Andrei')
         a.update()
-        self.assert_updated(a._table, a.fields.as_dict())
+        self.assert_updated(a.table_name, a.fields.as_dict())
 
     def test_existing_document_with_one_field(self):
         a = self.Artist.create(name='Andrei')
         a.update(country='Romania')
-        self.assert_updated(a._table, a.fields.as_dict())
+        self.assert_updated(a.table_name, a.fields.as_dict())
 
     def test_existing_document_with_several_fields(self):
         a = self.Artist.create(name='Andrei')
         a.update(country='Romania', city='Timisoara', male=True)
-        self.assert_updated(a._table, a.fields.as_dict())
+        self.assert_updated(a.table_name, a.fields.as_dict())
 
 
 class CallbackTests(DbBaseTestCase):
@@ -486,7 +484,7 @@ class CallbackTests(DbBaseTestCase):
         a = Artist()
         a.save()
         assert a['verified'] is True
-        self.assert_saved(a._table, a.fields.as_dict())
+        self.assert_saved(a.table_name, a.fields.as_dict())
 
     def test_after_save(self):
         class Artist(Model):
@@ -498,7 +496,7 @@ class CallbackTests(DbBaseTestCase):
         a = Artist()
         a.save()
         assert a['confirmed'] is False
-        self.assert_not_saved(a._table, a.fields.as_dict())
+        self.assert_not_saved(a.table_name, a.fields.as_dict())
 
     def test_before_delete(self):
         class Artist(Model):
@@ -510,7 +508,7 @@ class CallbackTests(DbBaseTestCase):
         a = Artist.create()
         a.delete()
         assert a['deleted'] is True
-        self.assert_deleted(a._table, a.fields.as_dict())
+        self.assert_deleted(a.table_name, a.fields.as_dict())
 
     def test_after_delete(self):
         class Artist(Model):
@@ -522,7 +520,7 @@ class CallbackTests(DbBaseTestCase):
         a = Artist.create()
         a.delete()
         assert a['deleted'] is True
-        self.assert_deleted(a._table, a.fields.as_dict())
+        self.assert_deleted(a.table_name, a.fields.as_dict())
 
     def test_after_init(self):
         class Artist(Model):


### PR DESCRIPTION
This simplifies how table names are handled, merging the private and the public API for this. There's no actual need for both `Model.table_name` and `Model._table`.