### PR TITLE
Manually restart RethinkDB on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   rethinkdb: 2.3
 install:
   - pip install .[dev]
+# TODO: This is (hopefully) only temporary, until Travis fixes it
 before_script: sudo service rethinkdb stop && sudo service rethinkdb start
 script: pytest
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   rethinkdb: 2.3
 install:
   - pip install .[dev]
+before_script: sudo service rethinkdb stop && sudo service rethinkdb start
 script: pytest
 deploy:
   provider: pypi


### PR DESCRIPTION
As described [here](https://travis-ci.community/t/rethinkdb-addon-does-not-start/3612), RethinkDB is apparently not started correctly on Travis. A manual restart seems to fix this.